### PR TITLE
fix: 教育背景配置后时间显示错误

### DIFF
--- a/src/components/FormCreator/index.tsx
+++ b/src/components/FormCreator/index.tsx
@@ -59,6 +59,9 @@ export const FormCreator: React.FC<Props> = props => {
   }, [props.value]);
 
   const handleChange = (values: any) => {
+    if ('edu_time' in values) {
+      values.edu_time = values.edu_time.split(',');
+    }
     props.onChange(values);
   };
   const formProps = {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89560943/159463375-3540cb05-c28d-41a0-8429-aa49f94b6cec.png)
导出json配置后，发现修改配置后的edu_time字段变成了字符串
![image](https://user-images.githubusercontent.com/89560943/159463710-ef2188ce-7eed-44d1-89f6-d1fdcedfbe4c.png)

正确显示应该是数组：
![image](https://user-images.githubusercontent.com/89560943/159463887-31f433c3-a90f-4ebc-ad9e-35cbfe431397.png)
