### PR TITLE
style: 解决打印pdf背景颜色丢失

### DIFF
--- a/src/pages/index.less
+++ b/src/pages/index.less
@@ -2,7 +2,9 @@
   .resume-content {
     box-shadow: none;
   }
-
+  body {
+    -webkit-print-color-adjust: exact;
+  }
   footer {
     display: none;
   }


### PR DESCRIPTION


<img width="446" alt="image" src="https://user-images.githubusercontent.com/66287770/230428885-c4b785e6-9df9-4393-bdaa-536f39b616f3.png">

## 添加body样式
```css
  body {
    -webkit-print-color-adjust: exact;
  }
```
<img width="434" alt="image" src="https://user-images.githubusercontent.com/66287770/230428796-c24ae677-fc85-4907-b233-78aa49403d7b.png">